### PR TITLE
Fix invalid boolean value for install_weak_deps option

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN dnf install --disablerepo="*" \
     --enablerepo="ubi-8-baseos-rpms" \
     --enablerepo="ubi-8-appstream-rpms" \
     --enablerepo="ubi-8-codeready-builder-rpms" \
-    --setopt install_weak_deps=false \
+    --setopt=install_weak_deps=0 \
     --nodocs -y \
     gcc \
     gcc-c++ \


### PR DESCRIPTION
This PR fixes the invalid boolean value `false`, which should be `0`. 