### PR TITLE
Update HDF5 and NumPy version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM redhat/ubi8:latest as builder
 
 ENV PIP_NO_CACHE_DIR=1 \
     HDF5_VERSION='1.14.6' \
-    NUMPY_VERSION='2.1.1' \
+    NUMPY_VERSION='2.2.5' \
     MIB_PROPS_VERSION='1.0.1'
 
 RUN dnf install --disablerepo="*" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN dnf install --disablerepo="*" \
     gcc \
     gcc-c++ \
     make \
+    cmake \
     wget \
     tar \
     zlib-devel \
@@ -29,44 +30,22 @@ RUN dnf install --disablerepo="*" \
 
 WORKDIR /opt
 
-RUN wget --quiet https://github.com/HDFGroup/hdf5/archive/refs/tags/hdf5-${HDF5_VERSION//./_}.tar.gz \
-    && gzip -cd hdf5-${HDF5_VERSION//./_}.tar.gz | tar xf - \
-    && mv hdf5-hdf5-${HDF5_VERSION//./_} hdf5-${HDF5_VERSION}
-
-# not sure how to disable examples in Autotools so just put them to /tmp and
-# they are not copied over, this is easier
-RUN cd hdf5-${HDF5_VERSION} \
-    && CFLAGS="-mavx2" \
-    ./configure \
-   --prefix=/usr/local \
-   --enable-build-mode=production \
-   --enable-shared \
-   --disable-static \
-   --disable-fortran \
-   --disable-cxx \
-   --disable-tools \
-   --disable-tests \
-   --with-examplesdir=/tmp && \
-   make -j$(nproc) && make install
-
-# CMake (need install) can disable examples, but the optimization level is not
-# high even this is Release, so not use it but worth keep it for later
-# investigation
-#RUN cd hdf5-${HDF5_VERSION} \
-    #&& mkdir -p build \
-    #&& cd build \
-    #&& cmake \
-    #-G "Unix Makefiles" \
-    #-DCMAKE_C_FLAGS:STRING="-mavx2" \
-    #-DCMAKE_INSTALL_PREFIX:STRING=/usr/local \
-    #-DZLIB_DIR:STRING=/usr/lib64/ \
-    #-DCMAKE_BUILD_TYPE:STRING=Release \
-    #-DBUILD_STATIC_LIBS:BOOL=OFF \
-    #-DHDF5_BUILD_TOOLS:BOOL=OFF \
-    #-DBUILD_TESTING:BOOL=OFF \
-    #-DHDF5_BUILD_EXAMPLES:BOOL=OFF \
-    #.. \
-    #&& make -j$(nproc) && make install
+RUN wget --quiet https://github.com/HDFGroup/hdf5/releases/download/hdf5_${HDF5_VERSION}/hdf5-${HDF5_VERSION}.tar.gz \
+    && gzip -cd hdf5-${HDF5_VERSION}.tar.gz | tar xf - \
+    && cd hdf5-${HDF5_VERSION} \
+    && mkdir -p build \
+    && cd build \
+    && cmake \
+    -G "Unix Makefiles" \
+    -DCMAKE_C_FLAGS:STRING="-mavx2 -O3" \
+    -DCMAKE_INSTALL_PREFIX:STRING=/usr/local \
+    -DCMAKE_BUILD_TYPE:STRING=Release \
+    -DBUILD_STATIC_LIBS:BOOL=OFF \
+    -DHDF5_BUILD_TOOLS:BOOL=OFF \
+    -DBUILD_TESTING:BOOL=OFF \
+    -DHDF5_BUILD_EXAMPLES:BOOL=OFF \
+    .. \
+    && make -j$(nproc) && make install
 
 # numpy without blas
 RUN git clone https://github.com/numpy/numpy.git \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM redhat/ubi8:latest as builder
 
 ENV PIP_NO_CACHE_DIR=1 \
-    HDF5_VERSION='1.14.3' \
+    HDF5_VERSION='1.14.6' \
     NUMPY_VERSION='2.1.1' \
     MIB_PROPS_VERSION='1.0.1'
 

--- a/UserExampleJson.json
+++ b/UserExampleJson.json
@@ -39,6 +39,12 @@
     },
     "process": {
         "PIE": {
+            "MultiSlice": {
+                "S_distance": 2e-9,
+                "slices": 1,
+                "test": 1,
+                "type": "phase"
+            },
             "decay": [
                 0.4,
                 0,

--- a/mib_convert.py
+++ b/mib_convert.py
@@ -1259,7 +1259,7 @@ def main():
                 aps = meta_values['aperture_size'][()]
             rot_angle,camera_length,conv_angle = Meta2Config(acc, nCL, aps)
 
-            gen_config(template_path, pty_dest_2, config_name, save_path +'/'+time_stamp+'.hdf', rot_angle, camera_length, 2*conv_angle)
+            gen_config(ptycho_template, pty_dest_2, ptycho_config, save_path +'/'+time_stamp+'.hdf', rot_angle, camera_length, 2*conv_angle)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR updates HDF5 version to 1.14.6 and NumPy to 2.2.3.

While updating the version of HDF5, the build tool is also updated to CMake instead of Autotools (as Autotools is being deprecated upstream). This fixes #1.

Some bugs are also fixed related to the generation of PtyREX config file with multi-slice options.