### PR TITLE
Fix passing big-endian array to C extension from litte-endian complier 

### DIFF
--- a/mib_convert.py
+++ b/mib_convert.py
@@ -995,8 +995,12 @@ def main():
                     # construct only the frame
                     arr = np.frombuffer(frame[header_size:], dtype=dtype_be)
 
+                    # convert from big-endian to little-endian
+                    arr_le = arr.byteswap()
+                    arr_le = arr_le.view(arr_le.dtype.newbyteorder())
+
                     # reshape to 2D for flipping
-                    resh = arr.reshape(det_y, det_x)
+                    resh = arr_le.reshape(det_y, det_x)
 
                     # flip it to match those from pyxem (but why?)
                     resh = np.flipud(resh)


### PR DESCRIPTION
This PR fixes the bug of incorrectly passing big-endian array (the raw MIB frame) to the fast binning C extension, which only works with little-endian array. While the raw MIB bytes should be interpreted by big-endian byte order, it should be converted to little-endian as soon as it can so that it is more compatible with the CPU architecture.

This issue was revealed by converting 12-bit MIB data and this was raised when the big-endian array is passed to the `fast_bin` C extension:
```python
ValueError: Big-endian buffer not supported on little-endian compiler
```